### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_deploy: |
     NPM_TAG="snapshot"
     SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
     UNIQ_PKG_VERSION="${PKG_VERSION}.${SHORT_COMMIT_HASH}"
-    TRAVIS_TAG="${UNIQ_PKG_VERSION}"
     npm --no-git-tag-version version ${UNIQ_PKG_VERSION}
   fi
 
@@ -31,9 +30,3 @@ deploy:
     on:
       repo: usgs/wdfn-viz
       branch: master
-  - provider: releases
-    api_key:
-      secure: "KmybpopBfW5zkrdnYzUmcP1P3wVFn7yFKOn47wXUhctJ1+kweqPUfs0l3w1RJ5HvZRJ2C66iPmgz/VmACWH9k8CfNiV1grgH/6Sgbq9rM7JJhO6wSDaaWIXYLD0Tz5dxYQksoC/Tw2vH+r/D9rcbwuo3u5gO51fH6uKJur0v1sZr/HChhzcMKYAv7S9zE9vel+KBI9ZI/CKMFViFAxVP4RMgqVjeHAPEpMHKimeHK4vjqyHuYkWHnPRD8emgBVojb7yrx+1doQzD/pl+ifBuMqKcgL8OcOhb36gvs4fO4KNHSfHLD8qFZaLynhScQv+Lud/FuyuAchWl+Kd67LSnsYYlcPYg3arDvkXvEsNhnisSj8nSLY1y564GcBRWW8KNjq3a3/X7vmfSvgPWs19ikAwo6sjOj/eajF7HV1yjpGiY2/fINcRGFkn8mez4ZMcFOeMPd43ecu0x+3k4xmnkNvq9A6VXPoJD1KQTho/qxHLx5RGzR9RdLQuhsLyoc18jhq9EKqPBsm4+xdphF/ikqJ9e5H0fi1TyGqPNM4O3vJGZyQoJl25i9ekYNLuTvfFju3os+U/jmnxP3BjHqzT8Iapg0l15qQX4/zvIWLGnsCbxcmosAau38I727+940qQmWYTLdjQubINdQ52S9QxAYPFaN10kXHd6wdD4dQ3Ip2U="
-    skip_cleanup: true
-    on:
-      tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.0.0]
 ### Changed
 - Updated build USWDS to 2.0.1
 - A git tag is created for each release
 
-[Unreleased]: : https://github.com/usgs/wdfn-viz/compare/wdfn-viz-1.0.0...master
-[1.0.0]: https://github.com/usgs/wdfn-viz/tree/wdfn-viz-1.0.0
+[Unreleased]: https://github.com/usgs/wdfn-viz/compare/wdfn-viz-0.10.0...master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0]
 ### Changed
 - Updated build USWDS to 2.0.1
 - A git tag is created for each release
 
-[Unreleased]: https://github.com/usgs/wdfn-viz/compare/wdfn-viz-0.10.0...master
+[Unreleased]: : https://github.com/usgs/wdfn-viz/compare/wdfn-viz-1.0.0...master
+[1.0.0]: https://github.com/usgs/wdfn-viz/tree/wdfn-viz-1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5363,8 +5363,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5385,14 +5384,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5407,20 +5404,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5537,8 +5531,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5550,7 +5543,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5565,7 +5557,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5573,14 +5564,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5599,7 +5588,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5680,8 +5668,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5693,7 +5680,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5779,8 +5765,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5816,7 +5801,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5836,7 +5820,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5880,14 +5863,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },


### PR DESCRIPTION
Removed previous attempts at tagging the github repo on a release. This was causing the travis build to fail.